### PR TITLE
#25: Fixed Broken OG Images for Blog Posts

### DIFF
--- a/app/(main-site)/blog/[slug]/page.tsx
+++ b/app/(main-site)/blog/[slug]/page.tsx
@@ -14,7 +14,7 @@ import ViewCounter from "../view-counter";
 
 export async function generateMetadata({ params }): Promise<Metadata> {
   const post = await client.fetch<PostSchemaType>(
-    `*[_type == "post" && slug.current == "${params.slug}"][0] && isArchived == false`,
+    `*[_type == "post" && slug.current == "${params.slug}" && isArchived == false][0]`,
     {
       next: {
         revalidate: 3600, // look for updates to revalidate cache every hour


### PR DESCRIPTION
## What was the issue?
- OpenGraph images were missing from blog posts due to an incorrect sanity query being used. This query returned null results causing the logic to generate post metadata to be skipped

## Images

### Resolved OpenGraph
![Resolved opengraph](https://github.com/darius-0x4d/darius-personal-site/assets/121631245/de873638-5536-4967-a2f5-7a2a2f96d7d0)
